### PR TITLE
Update NPCs to translate classes, crews, and factions

### DIFF
--- a/compendium/blades-in-the-dark.npc.json
+++ b/compendium/blades-in-the-dark.npc.json
@@ -3,7 +3,10 @@
   "mapping": {
     "name": "name",
     "description": "system.description_short",
-    "long_description": "system.description"
+    "long_description": "system.description",
+    "playbook": "system.associated_class",
+    "crew": "system.associated_crew_type",
+    "faction": "system.associated_faction"
   },
   "folders": {},
   "entries": {
@@ -11,289 +14,433 @@
       "name": "Roslyn Kellis",
       "tokenName": "Roslyn Kellis",
       "description": "aristocrata",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Furtivo",
+      "crew": "",
+      "faction": ""
     },
     "0c2iOYT6dnwTyWpP": {
       "name": "Bryl",
       "tokenName": "Bryl",
       "description": "traficante",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Suave",
+      "crew": "",
+      "faction": ""
     },
     "0dqDU68OAo3b4kVo": {
       "name": "Marlo",
       "tokenName": "Marlo",
       "description": "chefe de gangue",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Mascates",
+      "faction": ""
     },
     "0iQxdTXoETXFbJG9": {
       "name": "Jennah",
       "tokenName": "Jennah",
       "description": "camareira",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Aranha",
+      "crew": "",
+      "faction": ""
     },
     "0zM5aJkLXJIIymsx": {
       "name": "Setarra",
       "tokenName": "Setarra",
       "description": "demônio",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Sussurro",
+      "crew": "",
+      "faction": ""
     },
     "1gzpJBEG7Wu7PQZK": {
       "name": "Klyra",
       "tokenName": "Klyra",
       "description": "dona de taverna",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Suave",
+      "crew": "",
+      "faction": ""
     },
     "1v3mJmkKonLtJFMq": {
       "name": "Dowler",
       "tokenName": "Dowler",
       "description": "explorador",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Sombras",
+      "faction": ""
     },
     "2VuLIj4Z8elDAXwN": {
       "name": "Nyryx",
       "tokenName": "Nyryx",
       "description": "prostituto(a)",
-      "long_description": ""
+      "long_description": "Fantasma trapaceiro que possui o corpo de prostitutas. Busca um Sussurro para servir.",
+      "playbook": "Sussurro",
+      "crew": "",
+      "faction": ""
     },
     "2tLWJkQKO7WUkmsh": {
       "name": "Grull",
       "tokenName": "Grull",
       "description": "bandido intermediário",
-      "long_description": "Um bandido intermediário com grandes ambições."
+      "long_description": "Um bandido intermediário com grandes ambições.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "3atXPa9OUT9OCcV8": {
       "name": "Anya",
       "tokenName": "Anya",
       "description": "diletante",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Mascates",
+      "faction": ""
     },
     "4NyIdaeb3WXzzF8Y": {
       "name": "Lutes",
       "tokenName": "Lutes",
       "description": "dono de taverna",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Bravos",
+      "faction": ""
     },
     "5ShKuFoaI9Bj07u3": {
       "name": "Walker",
       "tokenName": "Walker",
       "description": "chefe do bairro",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Bravos",
+      "faction": ""
     },
     "5Zs4L0FD9aDh8Aks": {
       "name": "Jul",
       "tokenName": "Jul",
       "description": "traficante de sangue",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Doutor",
+      "crew": "",
+      "faction": ""
     },
     "5mS0X3Kn52xhnv8O": {
       "name": "Elynn",
       "tokenName": "Elynn",
       "description": "tabeliã das docas",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Contrabandistas",
+      "faction": ""
     },
     "618tZppqt7Vti8UG": {
       "name": "Elstera Avrathi",
       "tokenName": "Elstera Avrathi",
       "description": "diplomata",
-      "long_description": "Diplomata residente em Iruvia."
+      "long_description": "Diplomata residente em Iruvia.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "6DZugMzukUHAIfHQ": {
       "name": "Marlane",
       "tokenName": "Marlane",
       "description": "pugilista",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Retalhador",
+      "crew": "",
+      "faction": ""
     },
     "6EzDG4jPx6mDWgFL": {
       "name": "Brynna Skyrkallan",
       "tokenName": "Brynna Skyrkallan",
       "description": "diplomata",
-      "long_description": "Diplomata residente em Skovlan."
+      "long_description": "Diplomata residente em Skovlan.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "6tcUNrwx5F3L7TYD": {
       "name": "Keller",
       "tokenName": "Keller",
       "description": "ferreiro",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Bravos",
+      "faction": ""
     },
     "70n7J94dCEDzteY6": {
       "name": "Sevoy",
       "tokenName": "Sevoy",
       "description": "lorde mercantil",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Assassinos",
+      "faction": ""
     },
     "7gADzdqKREm9PeOr": {
       "name": "Malista",
       "tokenName": "Malista",
       "description": "sacerdotisa",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Doutor",
+      "crew": "",
+      "faction": ""
     },
     "85NbHF5VR9XZUII7": {
       "name": "Moriya",
       "tokenName": "Moriya",
       "description": "traficante de espíritos",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Culto",
+      "faction": ""
     },
     "8DGnUGMorYWXcUVV": {
       "name": "Denkirk Sol",
       "tokenName": "Denkirk Sol",
       "description": "advogado",
-      "long_description": "Advogado com escrúpulos surpreendentes."
+      "long_description": "Advogado com escrúpulos surpreendentes.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "8FjFGa6riyc6J0vm": {
       "name": "Otto",
       "tokenName": "Otto",
       "description": "cocheiro",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Vampiro",
+      "crew": "",
+      "faction": ""
     },
     "CB6nordTDnVkCn3q": {
       "name": "Mordis",
       "tokenName": "Mordis",
       "description": "mercador",
-      "long_description": "Mercador do Empório da Noite. Esconde sua aparência por baixo de robes e capuzes."
+      "long_description": "Mercador do Empório da Noite. Esconde sua aparência por baixo de robes e capuzes.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "CqNC8XaFdloJ5bCm": {
       "name": "Cinda",
       "tokenName": "Cinda",
       "description": "Casaca Azul",
-      "long_description": "Casaca Azul de posto raso."
+      "long_description": "Casaca Azul de posto raso.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "DrRiS7RM4xczvckN": {
       "name": "Augus",
       "tokenName": "Augus",
       "description": "mestre arquiteto",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Aranha",
+      "crew": "",
+      "faction": ""
     },
     "Dv29btX5yhOkX8Pu": {
       "name": "Chael",
       "tokenName": "Chael",
       "description": "bandido cruel",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Retalhador",
+      "crew": "",
+      "faction": ""
     },
     "EC8GRUiMI22icqZ7": {
       "name": "Alon Helker",
       "tokenName": "Alon Helker",
       "description": "juiz-inspetor",
-      "long_description": "Juiz-inspetor. Combate a corrupção."
+      "long_description": "Juiz-inspetor. Combate a corrupção.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "EPtgobw8OrbmGml4": {
       "name": "Veldren",
       "tokenName": "Veldren",
       "description": "psiconauta",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Doutor",
+      "crew": "",
+      "faction": ""
     },
     "FDVzvTH7KbL0rKHF": {
       "name": "Jira",
       "tokenName": "Jira",
       "description": "contrabandista",
-      "long_description": "Vendedor do Empório da Noite. Contrabandista."
+      "long_description": "Vendedor do Empório da Noite. Contrabandista.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "FynAEk2WHTZu3NMe": {
       "name": "Harker",
       "tokenName": "Harker",
       "description": "presidiário reincidente",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Suave",
+      "crew": "",
+      "faction": ""
     },
     "GMEEGL4asCC42DcU": {
       "name": "Grace",
       "tokenName": "Grace",
       "description": "assaltante",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Retalhador",
+      "crew": "",
+      "faction": ""
     },
     "GZKmaRNMFqaoFxHw": {
       "name": "Flint",
       "tokenName": "Flint",
       "description": "traficante de espíritos",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Sussurro",
+      "crew": "",
+      "faction": ""
     },
     "HAMiLXn0uSMHWhwK": {
       "name": "Lewit",
-      "tokenName": "Jewit",
+      "tokenName": "Lewit",
       "description": "Casaca Azul",
-      "long_description": "Casaca Azul de posto raso."
+      "long_description": "Casaca Azul de posto raso.",
+      "playbook": "",
+      "crew": "",
+      "faction": "Bluecoats"
     },
     "I31atP3bkNYwpNWs": {
       "name": "Laroze",
       "tokenName": "Laroze",
       "description": "Casaca Azul",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Sombras",
+      "faction": ""
     },
     "ILq3pmW1eP5Cmv5N": {
       "name": "Bazso Baz",
       "tokenName": "Bazso Baz",
       "description": "líder dos Lanternas Negras",
-      "long_description": "Líder dos Lanternas Negras. Ama uísque."
+      "long_description": "Líder dos Lanternas Negras. Ama uísque.",
+      "playbook": "Suave",
+      "crew": "",
+      "faction": ""
     },
     "JB5kuBYiG1WM68Jn": {
       "name": "Merrul Brime",
       "tokenName": "Merrul Brime",
       "description": "agente dos segredos",
-      "long_description": "Agente dos segredos. Proprietária do Raposa Encapuzada."
+      "long_description": "Agente dos segredos. Proprietária do Raposa Encapuzada.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "KV64FoCmAHQfgjgk": {
       "name": "A Estrela",
       "tokenName": "A Estrela",
       "description": "capitão de gangue anônimo",
-      "long_description": "Capitão da gangue Os Velados."
+      "long_description": "Capitão da gangue Os Velados.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "KzFTrQfdHBRYTdXc": {
       "name": "Mercy",
       "tokenName": "Mercy",
       "description": "assassina fria",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Retalhador",
+      "crew": "",
+      "faction": ""
     },
     "LNRHhNkWokxfuAkd": {
       "name": "Adikin",
       "tokenName": "Adikin",
       "description": "ocultista",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Culto",
+      "faction": ""
     },
     "M5aVr5wpzVCs7Tla": {
       "name": "Decker",
       "tokenName": "Decker",
       "description": "anarquista",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Contrabandistas",
+      "faction": ""
     },
     "MKxJXmKpXjcC3m2N": {
       "name": "Adelaide Phroaig",
       "tokenName": "Adelaide Phroaig",
       "description": "nobre",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Sombras",
+      "faction": ""
     },
     "MNK1Z6n6uBxGuI0P": {
       "name": "Thomas",
       "tokenName": "Thomas",
       "description": "médico",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Bravos",
+      "faction": ""
     },
     "PB7HIiVRsSMA00GX": {
       "name": "Stazia",
       "tokenName": "Stazia",
       "description": "apotecária",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Doutor",
+      "crew": "",
+      "faction": ""
     },
     "Qrllp11M6C2Bt5v5": {
       "name": "Andris",
       "tokenName": "Andris",
       "description": "espião e informante",
-      "long_description": "Espião e informante com lealdade flexível."
+      "long_description": "Espião e informante com lealdade flexível.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "QsFjJ0BlOpCHca8l": {
       "name": "Riven",
       "tokenName": "Riven",
       "description": "química",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Aranha",
+      "crew": "",
+      "faction": ""
     },
     "REa4y6EVchOVsTRU": {
       "name": "Levyra",
       "tokenName": "Levyra",
       "description": "uma médium",
-      "long_description": ""
+      "long_description": "A spirit medium.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "Rf8pPh9WMIjSlC3B": {
       "name": "Nyelle",
       "tokenName": "Nyelle",
       "description": "traficante de espíritos",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Contrabandistas",
+      "faction": ""
     },
     "RwX4a6msJzaqrfS7": {
       "name": "Laroze",
@@ -305,289 +452,433 @@
       "name": "Ulf Filho do Ferro",
       "tokenName": "Ulf Filho do Ferro",
       "description": "Skovlandês brutal",
-      "long_description": "Um Skovlandês brutal; anseia poder"
+      "long_description": "Um Skovlandês brutal; anseia poder",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "U4CdQLttZEnI0krf": {
       "name": "Jol",
       "tokenName": "Jol",
       "description": "Casaca Azul",
-      "long_description": "Casaca Azul de posto raso."
+      "long_description": "Casaca Azul de posto raso.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "UT9rmiFa3QA2hGWF": {
       "name": "Kira",
       "tokenName": "Kira",
       "description": "guarda-costas",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Vampiro",
+      "crew": "",
+      "faction": ""
     },
     "W4trwZmosVThWdOk": {
       "name": "Gagan",
       "tokenName": "Gagan",
       "description": "acadêmico",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Culto",
+      "faction": ""
     },
     "W5OEkmbwBKQpBbto": {
       "name": "Rutherford",
       "tokenName": "Rutherford",
       "description": "mordomo",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Vampiro",
+      "crew": "",
+      "faction": ""
     },
     "X3OBrpfnMMBKTpWp": {
       "name": "Fitz",
       "tokenName": "Fitz",
       "description": "colecionador",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Sombras",
+      "faction": ""
     },
     "YduTDcozzx1qNXx1": {
       "name": "Trev",
       "tokenName": "Trev",
       "description": "chefe de gangue",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Assassinos",
+      "faction": ""
     },
     "Yp4xdx8I7X272p8p": {
       "name": "Taffer",
       "tokenName": "Taffer",
       "description": "um comerciante",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "ZBW7oMTnvkGzIesX": {
       "name": "Lyssa",
       "tokenName": "Lyssa",
       "description": "chefe do crime",
-      "long_description": "Fria e calculista. A ssassinou Roric, chefe anterior de sua facção."
+      "long_description": "Fria e calculista. A ssassinou Roric, chefe anterior de sua facção.",
+      "playbook": "",
+      "crew": "asdf",
+      "faction": ""
     },
     "aZ6Yad2ylZgjmBsX": {
       "name": "Krop",
       "tokenName": "Krop",
       "description": "Casaca Azul",
-      "long_description": "Casaca Azul de posto raso. Recusa subornos."
+      "long_description": "Casaca Azul de posto raso. Recusa subornos.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "agLEN2UAeXB4ObDb": {
       "name": "Reyf",
       "tokenName": "Reyf",
       "description": "Casaca Azul",
-      "long_description": "Casaca Azul de posto raso."
+      "long_description": "Casaca Azul de posto raso.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "bjsPt4t8gAGccmBG": {
       "name": "Ereth Skane",
       "tokenName": "Ereth Skane",
       "description": "advogado",
-      "long_description": "Advogado com vícios obscenos."
+      "long_description": "Advogado com vícios obscenos.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "ciay0O0p7WoWUZFU": {
       "name": "Melvir",
       "tokenName": "Melvir",
       "description": "médico",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Cão de Caça",
+      "crew": "",
+      "faction": ""
     },
     "cqMSaWVZMBJz8vTm": {
       "name": "Conway",
       "tokenName": "Conway",
       "description": "Casaca Azul",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Bravos",
+      "faction": ""
     },
     "dhjrdVoP5AhVRxjK": {
       "name": "Sera",
       "tokenName": "Sera",
       "description": "traficante de armas",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Contrabandistas",
+      "faction": ""
     },
     "eWNXot2ruOTUIJii": {
       "name": "Scurlock",
       "tokenName": "Scurlock",
       "description": "vampiro",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Sussurro",
+      "crew": "",
+      "faction": ""
     },
     "eqs0gysadnzyN7ob": {
       "name": "Rolan",
       "tokenName": "Rolan",
       "description": "traficante de drogas",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Contrabandistas",
+      "faction": ""
     },
     "fYqZyYPdnIquzGMy": {
       "name": "Esme",
       "tokenName": "Esme",
       "description": "dona de taverna",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Contrabandistas",
+      "faction": ""
     },
     "fgirUoJ2WjQxUztx": {
       "name": "Hoxan",
       "tokenName": "Hoxan",
       "description": "fantasma trapaceiro",
-      "long_description": "Fantasma trapaceiro que possui o corpo de prostitutas. Busca um Sussurro para servir."
+      "long_description": "Fantasma trapaceiro que possui o corpo de prostitutas. Busca um Sussurro para servir.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "g72agS6oSgWFCgJJ": {
       "name": "Meg",
       "tokenName": "Meg",
       "description": "lutadora de arena",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Bravos",
+      "faction": ""
     },
     "gCKmHwBUDHPCJnwX": {
       "name": "Telda",
       "tokenName": "Telda",
       "description": "mendiga",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Furtivo",
+      "crew": "",
+      "faction": ""
     },
     "gJpfsbebbBNc6hHW": {
       "name": "Jeren",
       "tokenName": "Jeren",
       "description": "Casaca Azul arquivista",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Aranha",
+      "crew": "",
+      "faction": ""
     },
     "gZsYRwAscDkztlpF": {
       "name": "Salia",
       "tokenName": "Salia",
       "description": "negociante de informações",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Aranha",
+      "crew": "",
+      "faction": ""
     },
     "h2sERuS38m6M6RoO": {
       "name": "Steiner",
       "tokenName": "Steiner",
       "description": "assassino",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Cão de Caça",
+      "crew": "",
+      "faction": ""
     },
     "hOAMFYasdCU03dA9": {
       "name": "Mylera Klev",
       "tokenName": "Mylera Klev",
       "description": "líder d'Os Faixas Escarlate",
-      "long_description": "Líder d'Os Faixas Escarlate. Colecionadora de arte."
+      "long_description": "Líder d'Os Faixas Escarlate. Colecionadora de arte.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "hx2q7lNku9XNvucg": {
       "name": "Rolan Wott",
       "tokenName": "Rolan Wott",
       "description": "juiz",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Mascates",
+      "faction": ""
     },
     "ilHqjIG9oIfitVqQ": {
       "name": "Belindra",
       "tokenName": "Belindra",
       "description": "carcereira",
-      "long_description": "Carcereira na Prisão Anzolférreo."
+      "long_description": "Carcereira na Prisão Anzolférreo.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "j9bP54KzEuox3wVs": {
       "name": "Lydra",
       "tokenName": "Lydra",
       "description": "negociante de informações",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Mascates",
+      "faction": ""
     },
     "jfcG42HF8e03QbPe": {
       "name": "Lady Drake",
       "tokenName": "Lady Drake",
       "description": "juíza",
-      "long_description": "Uma juíza que aceita suborno dos criminosos."
+      "long_description": "Uma juíza que aceita suborno dos criminosos.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "lauDCN0yKkakO2Tc": {
       "name": "Kember",
       "tokenName": "Kember",
       "description": "destiladora",
-      "long_description": "Destiladora de essências e poções, proprietária da taverna Dente de Demônio."
+      "long_description": "Destiladora de essências e poções, proprietária da taverna Dente de Demônio.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "m5T6yxATPH5aT18N": {
       "name": "Polix",
       "tokenName": "Polix",
       "description": "adido do Lorde Governador",
-      "long_description": "Adido do Lorde Governador de Doskvol. Age secretamente como espiritualista."
+      "long_description": "Adido do Lorde Governador de Doskvol. Age secretamente como espiritualista.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "mzCgZ2Ppsgz3jfaY": {
       "name": "Raffello",
       "tokenName": "Raffello",
       "description": "grande pintor",
-      "long_description": "Grande pintor obcecado com o sobrenatural."
+      "long_description": "Grande pintor obcecado com o sobrenatural.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "n2DiFdtRDx0ktkIp": {
       "name": "Hutchins",
       "tokenName": "Hutchins",
       "description": "antiquário",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Culto",
+      "faction": ""
     },
     "nNjGWOnDjqIxrE9Z": {
       "name": "Lylandra",
       "tokenName": "Lylandra",
       "description": "consorte",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Vampiro",
+      "crew": "",
+      "faction": ""
     },
     "naVuCXYzVZ8gNPFS": {
       "name": "Eckerd",
       "tokenName": "Eckerd",
       "description": "ladrão de cadáveres",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Doutor",
+      "crew": "",
+      "faction": ""
     },
     "nkDUMJMJA2XVSw7Y": {
       "name": "Amancio",
       "tokenName": "Amancio",
       "description": "intermediário",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Sombras",
+      "faction": ""
     },
     "o4qeCfd3PbbPqTYg": {
       "name": "Hoxley",
       "tokenName": "Hoxley",
       "description": "contrabandista",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Mascates",
+      "faction": ""
     },
     "oIHOCivkkpgCPQON": {
       "name": "Exeter",
       "tokenName": "Exeter",
       "description": "Patrulheiro Espiritual",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Assassinos",
+      "faction": ""
     },
     "ovZxvDiN43mWXJ5S": {
       "name": "Sawtooth",
       "tokenName": "Sawtooth",
       "description": "médico",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Retalhador",
+      "crew": "",
+      "faction": ""
     },
     "q0jvrMosQ0RWGPFq": {
       "name": "Celene",
       "tokenName": "Celene",
       "description": "sentinela",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Cão de Caça",
+      "crew": "",
+      "faction": ""
     },
     "q8ii3If0HqBwkEvA": {
       "name": "Lannic",
       "tokenName": "Lannic",
       "description": "um perito em arte",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "qUNWkNrvTYbziv3i": {
       "name": "Irimina",
       "tokenName": "Irimina",
       "description": "nobre cruel",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Assassinos",
+      "faction": ""
     },
     "rcvTVk6tSI0qVWzL": {
       "name": "A Torre",
       "tokenName": "A Torre",
       "description": "líder de gangue anônimo",
-      "long_description": "Líder anônimo d'Os Velados."
+      "long_description": "Líder anônimo d'Os Velados.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "sviELYOUNEyY9X0L": {
       "name": "Veleris",
       "tokenName": "Veleris",
       "description": "espiã",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Cão de Caça",
+      "crew": "",
+      "faction": ""
     },
     "u3fzAfPNzr63bagc": {
       "name": "Frake",
       "tokenName": "Frake",
       "description": "chaveiro",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Furtivo",
+      "crew": "",
+      "faction": ""
     },
     "u9HiZdG7fnbyV6zP": {
       "name": "Casslyn Mora",
       "tokenName": "Casslyn Mora",
       "description": "juíza",
-      "long_description": "Juíza. Familiares envolvidos com criminosos."
+      "long_description": "Juíza. Familiares envolvidos com criminosos.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "u9nBCFx60JXVNz8y": {
       "name": "Edrik",
       "tokenName": "Edrik",
       "description": "emissário",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Vampiro",
+      "crew": "",
+      "faction": ""
     },
     "uoZc1jHjWkoiakVb": {
       "name": "Mateas Kline",
       "tokenName": "Mateas Kline",
       "description": "nobre",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Culto",
+      "faction": ""
     },
     "vQ3FlOJzCMnYvjT8": {
       "name": "Lydra",
@@ -599,37 +890,55 @@
       "name": "Tyrsin Nol",
       "tokenName": "Tyrsin Nol",
       "description": "diplomata",
-      "long_description": "Diplomata residente em Severos."
+      "long_description": "Diplomata residente em Severos.",
+      "playbook": "",
+      "crew": "",
+      "faction": ""
     },
     "wd9xtT5NlgzjotHX": {
       "name": "Bennett",
       "tokenName": "Bennett",
       "description": "astrônomo",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Culto",
+      "faction": ""
     },
     "x1cYr44EmfRgEV8s": {
       "name": "Rigney",
       "tokenName": "Rigney",
       "description": "dono de taverna",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Sombras",
+      "faction": ""
     },
     "xADDGHYtviNBg1Bh": {
       "name": "Petra",
       "tokenName": "Petra",
       "description": "funcionária da prefeitura",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Furtivo",
+      "crew": "",
+      "faction": ""
     },
     "yDAiIcche7dJvGR1": {
       "name": "Karlos",
       "tokenName": "Karlos",
       "description": "caçador de recompensas",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "",
+      "crew": "Assassinos",
+      "faction": ""
     },
     "yR1mWS2oIa1zhx1d": {
       "name": "Quellyn",
       "tokenName": "Quellyn",
       "description": "perita em bruxaria",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Sussurro",
+      "crew": "",
+      "faction": ""
     },
     "yxUUWgO2ppFU9JYG": {
       "name": "Nyryx",
@@ -641,13 +950,19 @@
       "name": "Darmot",
       "tokenName": "Darmot",
       "description": "Casaca Azul",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Furtivo",
+      "crew": "",
+      "faction": ""
     },
     "zRJxO6q9gpWdt1gM": {
       "name": "Casta",
       "tokenName": "Casta",
       "description": "caçadora de recompensas",
-      "long_description": ""
+      "long_description": "",
+      "playbook": "Cão de Caça",
+      "crew": "",
+      "faction": ""
     }
   }
 }


### PR DESCRIPTION
Using this module with Babele, the translations of NPCs did not cover the associated class, associated crew type, or associated factions. This caused the import contact functions of the Blades in the Dark game system to not properly wrok, as noted in [this issue](https://github.com/Dez384/foundryvtt-blades-in-the-dark/issues/39). 

This PR will add the additional translations to the NPC compendium and allow the Blades in the Dark game system to function properly while using this module and Babele.